### PR TITLE
Assembly rename and UdtNetworkStream visibility

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/.idea.udtsharp/.idea/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,2 +1,0 @@
-# Default ignored files
-/.idea.udtsharp/.idea/workspace.xml

--- a/src/UdtNetworkStream.cs
+++ b/src/UdtNetworkStream.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace UdtSharp
 {
-    class UdtNetworkStream : Stream
+    public class UdtNetworkStream : Stream
     {
         public UdtNetworkStream(UdtSocket socket)
         {

--- a/udtsharp.csproj
+++ b/udtsharp.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>udtperftest</AssemblyName>
     <RootNamespace>udtperftest</RootNamespace>
     <StartupObject>UdtPerfTest.Program</StartupObject>
   </PropertyGroup>

--- a/udtsharp.csproj
+++ b/udtsharp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>udtsharp</AssemblyName>
     <RootNamespace>udtperftest</RootNamespace>
     <StartupObject>UdtPerfTest.Program</StartupObject>
   </PropertyGroup>


### PR DESCRIPTION
I have changed the assembly name from udtperftest.dll to udtsharp.dll. Also, UdtNetworkStream is now a public class, to be able to use it in other projects. 